### PR TITLE
Update server.js

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -65,7 +65,14 @@ var strategy = new uwshib.Strategy({
     entityId: domain,
     privateKey: privateKey,
     callbackUrl: loginCallbackUrl,
-    domain: domain
+    domain: domain,
+    //If your server is not using time.u.washington.edu
+    //as its authoritative time server (including if your
+    //server is running within the NetID domain!), uncomment
+    //the following line. This will allow for a small amount of
+    //skew between the clocks of the client and the server.
+    //
+    //acceptedClockSkewMs: 200
 });
 
 passport.use(strategy);


### PR DESCRIPTION
Added a comment block containing a line that sets an additional saml.Strategy options property during the example uwshib.Strategy construction. This property defaults to 0 milliseconds, which assumes the client and the server are using the same authoritative time server. This addition allows for a small amount of skew between the client and the server's clock.
