### PR TITLE
adding gws_groups attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ var profileAttrs = {
     'urn:oid:2.5.4.4': 'surname',
     'urn:oid:2.5.4.12': 'title',
     'urn:oid:1.2.840.113994.200.21': 'studentId',
-    'urn:oid:1.2.840.113994.200.24': 'regId'
+    'urn:oid:1.2.840.113994.200.24': 'regId',
+    'urn:oid:1.3.6.1.4.1.5923.1.5.1.1': 'gws_groups'
 };
 
 function verifyProfile(profile, done) {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var profileAttrs = {
     'urn:oid:2.5.4.12': 'title',
     'urn:oid:1.2.840.113994.200.21': 'studentId',
     'urn:oid:1.2.840.113994.200.24': 'regId',
-    'urn:oid:1.3.6.1.4.1.5923.1.5.1.1': 'gws_groups'
+    'urn:oid:1.3.6.1.4.1.5923.1.5.1.1': 'gwsGroups'
 };
 
 function verifyProfile(profile, done) {


### PR DESCRIPTION
There are tons of attributes listed at https://wiki.cac.washington.edu/display/infra/Guide+to+NameID+Formats+and+Attributes+Available+from+the+UW+IdP but this small change gets the gws_group one in there which is very useful.
